### PR TITLE
Speedup CB loading via indexing

### DIFF
--- a/assigner.py
+++ b/assigner.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
 		if options.bclist:
 			true_BCs = pd.read_table(options.bclist, header=None)
 			true_BCs = set(true_BCs[0].values)
-			mrg_sel = mrg_sel.loc[[not bc in true_BCs for bc in mrg_sel["BC"].values]]
+			mrg_sel = mrg_sel.loc[[not bc in true_BCs for bc in mrg_sel["BC"].values]].copy()
 
 		with poolcontext(processes = options.ncores) as pool:
 			pool.map(partial(wrapping.batch_seq_comp, target = mrg_sel, options = options), queries)

--- a/assigner.py
+++ b/assigner.py
@@ -93,13 +93,18 @@ if __name__ == "__main__":
 		### select BCs based on a file of previously defined barcodes
 		if options.srl:
 			defined_BCs = pd.read_table(options.srl, header=None)
-			defined_BCs = set(true_BCs[0].values)
+			defined_BCs = set(defined_BCs[0].values)
 
 			queries = mrg_sel.iloc[0:(mrg_sel.shape[0] - 1)].values.tolist()
 			queries = [q for q in queries if q[1] in defined_BCs]
 
 		else:
 			queries = mrg_sel.iloc[0:(mrg_sel.shape[0] - 1)].values.tolist()[:cell_no_ext]
+
+		if options.bclist:
+			true_BCs = pd.read_table(options.bclist, header=None)
+			true_BCs = set(true_BCs[0].values)
+			mrg_sel = mrg_sel.loc[[not bc in true_BCs for bc in mrg_sel["BC"].values]]
 
 		with poolcontext(processes = options.ncores) as pool:
 			pool.map(partial(wrapping.batch_seq_comp, target = mrg_sel, options = options), queries)

--- a/assigner.py
+++ b/assigner.py
@@ -107,8 +107,8 @@ if __name__ == "__main__":
 		#===merging CB===
 		step_time = time.time()
 		print("Merging table...", flush = True)
-		### TODO: only keep real BCs
-		res_df = wrapping.merge_cb_new(mrg_sel, options)
+		BC_index = [q[0] for q in queries]
+		res_df = wrapping.merge_cb_new(BC_index, options)
 		print("Done", flush = True)
 		hours, minutes, seconds = misc.get_time_elapse(step_time)
 		misc.report_time_elapse(hours, minutes, seconds)

--- a/assigner.py
+++ b/assigner.py
@@ -78,6 +78,7 @@ if __name__ == "__main__":
 
 		#===Calc distance===
 		print("Computing Levenshtein distance", flush = True)
+		step_time = time.time()
 
 # mrg_sel:
 #          idx                BC
@@ -108,6 +109,9 @@ if __name__ == "__main__":
 
 		with poolcontext(processes = options.ncores) as pool:
 			pool.map(partial(wrapping.batch_seq_comp, target = mrg_sel, options = options), queries)
+
+		hours, minutes, seconds = misc.get_time_elapse(step_time)
+		misc.report_time_elapse(hours, minutes, seconds)
 
 		#===merging CB===
 		step_time = time.time()

--- a/assigner.py
+++ b/assigner.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
 		if options.bclist:
 			true_BCs = pd.read_table(options.bclist, header=None)
 			true_BCs = set(true_BCs[0].values)
-			mrg_sel = mrg_sel.loc[[not bc in true_BCs for bc in mrg_sel["BC"].values]].copy()
+			mrg_sel = mrg_sel.loc[[not bc in true_BCs for bc in mrg_sel["BC"].values]]
 
 		with poolcontext(processes = options.ncores) as pool:
 			pool.map(partial(wrapping.batch_seq_comp, target = mrg_sel, options = options), queries)

--- a/assigner_core/preprocessing.py
+++ b/assigner_core/preprocessing.py
@@ -49,6 +49,9 @@ def getOptions():
 	parser.add_option("--smooth_res",  dest = "smooth_res",  nargs = 1, default = 0.001, type = float,
                           help = "Smoothening resolution on log10 scale. "
                                  "Default: 0.001")
+	parser.add_option("--srl", dest = "srl", nargs = 1, default = None,
+                          help = "barcode list file of barcode derived from short read data. In tsv.gz format. "
+                                 "Default: None")
 
 	return parser
 

--- a/assigner_core/preprocessing.py
+++ b/assigner_core/preprocessing.py
@@ -50,7 +50,10 @@ def getOptions():
                           help = "Smoothening resolution on log10 scale. "
                                  "Default: 0.001")
 	parser.add_option("--srl", dest = "srl", nargs = 1, default = None,
-                          help = "barcode list file of barcode derived from short read data. In tsv.gz format. "
+                          help = "file containing a list of known/defined barcodes (i.e derived from short read data)."
+                                 "Default: None")
+	parser.add_option("--bclist", dest = "bclist", nargs = 1, default = None,
+                          help = "file containing a list of all true barcodes."
                                  "Default: None")
 
 	return parser

--- a/assigner_core/wrapping.py
+++ b/assigner_core/wrapping.py
@@ -63,9 +63,6 @@ def estimate_rescue_cell_no(df):
 def batch_seq_comp(query, target, options):
 	import time, distance, os
 
-	print("Calculating Levenshtein distance on " + str(query[0]) + ": " + query[1] + " ...")
-	start_time = time.time()
-
 # target:
 #          idx                BC
 # 0          1  CTACGAAGTGATGAGG
@@ -80,13 +77,6 @@ def batch_seq_comp(query, target, options):
 	tmp_f = os.path.join(options.tmp_dir, "assigner_tmp_") + str(query[0]) + ".tsv"
 
 	target.loc[target["distance"] <= options.CB_mrg_thr, ["id1", "idx", "distance"]].to_csv(tmp_f, header = None, index = None, sep = "\t")
-
-	time_elapse = time.time() - start_time
-	hours   = time_elapse // 3600
-	rest_t  = time_elapse % 3600
-	minutes = rest_t // 60
-	seconds = rest_t % 60
-	print("Calc. LD on " + query[1] + " spent %d : %d : %.2f" % (hours, minutes, seconds))
 
 	return 1
 

--- a/assigner_core/wrapping.py
+++ b/assigner_core/wrapping.py
@@ -95,7 +95,7 @@ def seq_comp(batch_data, options):
 
 	return [batch_data['id1'], batch_data['id2'], distance.levenshtein(batch_data['BC1'], batch_data['BC2'])]
 
-def merge_cb_new(mrg_sel, options):
+def merge_cb_new(BC_index, options):
 	import pandas as pd
 	import os
 
@@ -115,11 +115,15 @@ def merge_cb_new(mrg_sel, options):
 	dist_df = pd.read_csv(options.CB_mrg_dist, sep = "\t", header = 0, compression = options.CB_mrg_dist_compression)
 
 	res = dict()
-	for idx in mrg_sel['idx']:
+	for idx in BC_index:
 		res[str(idx)] = str(idx)
 
 	for idx, row in dist_df.iterrows():
 		res[str(row['id2'])] = res[str(row['id1'])]
+
+	# remove those barcodes that are at equal distance to two other barcodes (not sure if this happends but still)
+	for idx in dist_df.id2.value_counts()[dist_df.id2.value_counts() > 1].index.tolist():
+		res.pop(str(idx))
 
 	return pd.DataFrame.from_dict(res, orient = 'index').reset_index().rename(columns = {'index': 'id1', 0: 'id2'})
 

--- a/assigner_core/wrapping.py
+++ b/assigner_core/wrapping.py
@@ -76,11 +76,11 @@ def batch_seq_comp(query, target, options):
 	num_8to16 = dna_to_int(query[1][8:])
 	num_7to15 = dna_to_int(query[1][7:15])
 
-	targetS = target.loc[(target["BC_1to8"].values == num_1to8) or
+	targetS = target.loc[(target["BC_1to8"].values == num_1to8) |
                          (target["BC_8to16"].values == num_8to16)]
 	targetS["INDEL"] = False
 
-	targetINDEL = target.loc[(target["BC_7to15"].values == num_8to16) or
+	targetINDEL = target.loc[(target["BC_7to15"].values == num_8to16) |
                              (target["BC_8to16"].values == num_7to15)]
 
 	target = pd.concet([targetS, targetINDEL])
@@ -91,7 +91,7 @@ def batch_seq_comp(query, target, options):
 
 	tmp_f = os.path.join(options.tmp_dir, "assigner_tmp_") + str(query[0]) + ".tsv"
 
-	target.loc[((target["distance"].values == 2) & (target["INDEL"].values)) or (target["distance"].values == 1),
+	target.loc[((target["distance"].values == 2) & (target["INDEL"].values)) | (target["distance"].values == 1),
 	           ["id1", "idx", "distance"]].to_csv(tmp_f, header = None, index = None, sep = "\t")
 
 	return 1

--- a/assigner_core/wrapping.py
+++ b/assigner_core/wrapping.py
@@ -166,8 +166,8 @@ def dna_to_int(dna_sequence):
 		ValueError: If sequence length isn't 8 or contains invalid characters
 	"""
 	# Validate input
-    if len(dna_sequence) != 8:
-        raise ValueError(f"DNA sequence must be exactly 8 characters long")
+	if len(dna_sequence) != 8:
+		raise ValueError(f"DNA sequence must be exactly 8 characters long")
 
 	valid_nucleotides = set('ACTG')
 	if not all(nuc in valid_nucleotides for nuc in dna_sequence):

--- a/assigner_core/wrapping.py
+++ b/assigner_core/wrapping.py
@@ -76,12 +76,12 @@ def batch_seq_comp(query, target, options):
 	num_8to16 = dna_to_int(query[1][8:])
 	num_7to15 = dna_to_int(query[1][7:15])
 
-	targetS = target[(target["BC_1to8"].values == num_1to8) or
-                     (target["BC_8to16"].values == num_8to16)]
+	targetS = target.loc[(target["BC_1to8"].values == num_1to8) or
+                         (target["BC_8to16"].values == num_8to16)]
 	targetS["INDEL"] = False
 
-	targetINDEL = target[(target["BC_7to15"].values == num_8to16) or
-					     (target["BC_8to16"].values == num_7to15)]
+	targetINDEL = target.loc[(target["BC_7to15"].values == num_8to16) or
+                             (target["BC_8to16"].values == num_7to15)]
 
 	target = pd.concet([targetS, targetINDEL])
 

--- a/assigner_core/wrapping.py
+++ b/assigner_core/wrapping.py
@@ -62,6 +62,7 @@ def estimate_rescue_cell_no(df):
 
 def batch_seq_comp(query, target, options):
 	import time, distance, os
+	import pandas as pd
 
 # target:
 #          idx                BC
@@ -77,13 +78,13 @@ def batch_seq_comp(query, target, options):
 	num_7to15 = dna_to_int(query[1][7:15])
 
 	targetS = target.loc[(target["BC_1to8"].values == num_1to8) |
-                         (target["BC_8to16"].values == num_8to16)]
-	targetS["INDEL"] = False
+                             (target["BC_8to16"].values == num_8to16)]
+	targetS.loc[:, "INDEL"] = False
 
 	targetINDEL = target.loc[(target["BC_7to15"].values == num_8to16) |
-                             (target["BC_8to16"].values == num_7to15)]
+                                 (target["BC_8to16"].values == num_7to15)]
 
-	target = pd.concet([targetS, targetINDEL])
+	target = pd.concat([targetS, targetINDEL])
 
 	target.loc[:, "id1"]      = query[0]
 	target.loc[:, "BC1"]      = query[1]

--- a/assigner_core/wrapping.py
+++ b/assigner_core/wrapping.py
@@ -84,12 +84,18 @@ def batch_seq_comp(query, target, options):
 		return 1
 
 	target.loc[:, "id1"]      = query[0]
-	target.loc[:, "BC1"]      = query[1]
 	target.loc[:, "distance"] = target["BC"].apply(lambda x: Levenshtein.distance(x, query[1], weights=(1,1,2)))
 
 	tmp_f = os.path.join(options.tmp_dir, "assigner_tmp_") + str(query[0]) + ".tsv"
 
-	target.loc[(target["distance"].values == 2), ["id1", "idx", "distance"]].to_csv(tmp_f, header = None, index = None, sep = "\t")
+	hits = target.loc[(target["distance"].values == 2)]
+	# its a ins followed by del (or other way around) if start and end match but no S and adding the first or last bp does not improve distance
+	ins2del = hits["BC"].apply(lambda x: (x[0] == query[1][0]) & (x[-1] == query[1][-1]) & \
+	                                     (Levenshtein.distance(x, query[1], weights=(1,1,1)) > 1) & \
+	                                     (Levenshtein.distance(x + query[1][-1], query[1], weights=(1,1,2)) > 1) & \
+	                                     (Levenshtein.distance(query[1][0] + x, query[1], weights=(1,1,2)) > 1))
+
+	hits.loc[~ins2del, ["id1", "idx", "distance"]].to_csv(tmp_f, header = None, index = None, sep = "\t")
 
 	return 1
 

--- a/assigner_core/wrapping.py
+++ b/assigner_core/wrapping.py
@@ -80,6 +80,9 @@ def batch_seq_comp(query, target, options):
 	                    (target["BC_7to15"].values == num_8to16) |
 	                    (target["BC_8to16"].values == num_7to15)]
 
+	if len(target) == 0:
+		return 1
+
 	target.loc[:, "id1"]      = query[0]
 	target.loc[:, "BC1"]      = query[1]
 	target.loc[:, "distance"] = target["BC"].apply(lambda x: Levenshtein.distance(x, query[1], weights=(1,1,2)))

--- a/curator.py
+++ b/curator.py
@@ -39,6 +39,7 @@ if __name__ == "__main__":
 	print("\nTime stamp: " + time.strftime("%a, %d %b %Y %H:%M:%S", time.localtime()), "\n", flush = True)
 	print("Loading CB_counting: " + options.CB_count + " ...", end = "", flush = True)
 	CB_counting_df = curator_io.load_df(options.CB_count)
+	CB_counting_df.set_index('idx', inplace=True)
 	print("Done", flush = True)
 
 	#===load CB_list===
@@ -48,20 +49,16 @@ if __name__ == "__main__":
 	CB_list = curator_io.open_file(options.CB_list, "rt")
 	#---skip def line---
 	CB_list.readline()
-	while True:
-		line = CB_list.readline()
-		if not line:
-			break
-
+	for line in CB_list:
 		lines = line.rstrip().split(": ")
 
-		rep_BC = CB_counting_df.loc[CB_counting_df['idx'] == int(lines[0]), ['BC']].values[0][0]
+		rep_BC = CB_counting_df.loc[int(lines[0]), 'BC']
 
 		all_id = curator_io.extract_id_list(lines[1])
 
-		BC_seq_list = CB_counting_df.loc[CB_counting_df['idx'].isin(all_id), ['BC']]
+		BC_seq_list = CB_counting_df.loc[all_id, 'BC']
 		for ele in BC_seq_list.values:
-			CB_dict[ele[0]] = rep_BC
+			CB_dict[ele] = rep_BC
 
 	CB_list.close()
 	print("Done", flush = True)


### PR DESCRIPTION
Hello,

Cell barcode loading was quite slow for me (~48 min for a file with 8000 barcodes) and I figured it was because accessing pandas data frame via column matching is quite slow. The implementation via indexing of the df speeds this up dramatically (less than 5 seconds for the same file for me), while producing the exact same dictionary (CB_dict, tested on two different files via md5).

I understand that this may not be a problem on all systems and definitely is not an issue on smaller dataset but maybe it helps others as well.

Cheers,
Philipp
